### PR TITLE
Add ucx-py

### DIFF
--- a/.ci_support/linux_cuda_compiler_version10.0.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.0.yaml
@@ -16,6 +16,14 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-cuda:10.0
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+- '3.6'
+- '3.7'
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_cuda_compiler_version10.1.yaml
@@ -16,6 +16,14 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-cuda:10.1
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+- '3.6'
+- '3.7'
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_version9.2.yaml
+++ b/.ci_support/linux_cuda_compiler_version9.2.yaml
@@ -16,6 +16,14 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-cuda:9.2
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+- '3.6'
+- '3.7'
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_cuda_compiler_versionNone.yaml
@@ -16,6 +16,14 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'
+- '3.6'
+- '3.7'
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Current release info
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ucx-green.svg)](https://anaconda.org/conda-forge/ucx) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ucx.svg)](https://anaconda.org/conda-forge/ucx) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ucx.svg)](https://anaconda.org/conda-forge/ucx) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ucx.svg)](https://anaconda.org/conda-forge/ucx) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ucx--proc-green.svg)](https://anaconda.org/conda-forge/ucx-proc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ucx-proc.svg)](https://anaconda.org/conda-forge/ucx-proc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ucx-proc.svg)](https://anaconda.org/conda-forge/ucx-proc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ucx-proc.svg)](https://anaconda.org/conda-forge/ucx-proc) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ucx--py-green.svg)](https://anaconda.org/conda-forge/ucx-py) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ucx-py.svg)](https://anaconda.org/conda-forge/ucx-py) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ucx-py.svg)](https://anaconda.org/conda-forge/ucx-py) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ucx-py.svg)](https://anaconda.org/conda-forge/ucx-py) |
 
 Installing ucx-split
 ====================
@@ -99,10 +100,10 @@ Installing `ucx-split` from the `conda-forge` channel can be achieved by adding 
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `ucx, ucx-proc` can be installed with:
+Once the `conda-forge` channel has been enabled, `ucx, ucx-proc, ucx-py` can be installed with:
 
 ```
-conda install ucx ucx-proc
+conda install ucx ucx-proc ucx-py
 ```
 
 It is possible to list all of the versions of `ucx` available on your platform with:

--- a/recipe/install_ucx-py.sh
+++ b/recipe/install_ucx-py.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+cd "${SRC_DIR}/ucx-py"
+$PYTHON -m pip install . -vv

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -12,6 +12,7 @@ if [ ${cuda_compiler_version} != "None" ]; then
     CUDA_CONFIG_ARG="--with-cuda=${CUDA_HOME}"
 fi
 
+cd "${SRC_DIR}/ucx"
 ./autogen.sh
 ./configure \
     --build="${BUILD}" \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,9 @@
 {% set ucx_version = "1.7.0.dev" %}
 {% set ucx_proc_version = "1.0.0" %}
 {% set ucx_commit = "9544fb9" %}
-{% set number = "4" %}
+{% set ucx_py_version = "0.1+179.g993ab90" %}
+{% set ucx_py_commit = "993ab90" %}  # from rapidsai's `branch-0.10`
+{% set number = "6" %}
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}
 
@@ -10,8 +12,12 @@ package:
   name: ucx-split
 
 source:
-  git_url: https://github.com/openucx/ucx
-  git_rev: {{ ucx_commit }}
+  - git_url: https://github.com/openucx/ucx
+    git_rev: {{ ucx_commit }}
+    folder: ucx
+  - git_url: https://github.com/rapidsai/ucx-py
+    git_rev: {{ ucx_py_commit }}
+    folder: ucx-py
 
 build:
   skip: true  # [not linux]
@@ -63,8 +69,45 @@ outputs:
       home: https://github.com/openucx/ucx
       license: BSD-3-Clause
       license_family: BSD
-      license_file: LICENSE
+      license_file: ucx/LICENSE
       summary: Unified Communication X.
+
+  - name: ucx-py
+    version: "{{ ucx_py_version }}"
+    build:
+      number: {{ number }}
+      skip: true  # [py<36]
+      ignore_run_exports:
+        - cudatoolkit                    # [cuda_compiler_version != "None"]
+    requirements:
+      build:
+        - {{ compiler("c") }}
+        - {{ compiler("cxx") }}
+        - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
+        - {{ cdt("libnl") }}
+        - {{ cdt("libibverbs") }}
+        - {{ cdt("librdmacm") }}
+      host:
+        - python
+        - pip
+        - cython
+        - ucx
+      run:
+        - python
+        - numpy
+        - {{ pin_subpackage("ucx", exact=True) }}
+      run_constrained:
+        - ucx-proc * {{ ucx_proc_type }}
+    script: install_ucx-py.sh
+    test:
+      imports:
+        - ucp
+    about:
+      home: https://github.com/rapidsai/ucx-py
+      license: BSD-3-Clause
+      license_family: BSD
+      license_file: ucx-py/LICENSE
+      summary: Python bindings for UCX
 
 about:
   home: https://github.com/openucx/ucx


### PR DESCRIPTION
Ports PR ( https://github.com/conda-forge/ucx-split-feedstock/pull/4 ) to the rapidsai feedstock. Like PR ( https://github.com/rapidsai/ucx-split-feedstock/pull/2 ) this adds the Python bits for gpuCI work on this feedstock.

cc @mike-wendt