### PR TITLE
ENH Add CDT for `libibcm-devel`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,7 +31,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libibverbs-devel librdmacm-devel numactl-devel
+/usr/bin/sudo -n yum install -y libibcm-devel libibverbs-devel librdmacm-devel numactl-devel
 
 
 # make the build number clobber

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,6 +101,7 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
+        - {{ cdt("libibcm") }}
         - {{ cdt("libibverbs") }}
         - {{ cdt("librdmacm") }}
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,6 @@ outputs:
         - {{ cdt("numactl-devel") }}
         - automake
         - autoconf
-        - libhwloc
         - libtool
         - make
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,6 +60,7 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
+        - {{ cdt("libibcm-devel") }}
         - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}
         - {{ cdt("numactl-devel") }}

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,3 +1,4 @@
+libibcm-devel
 libibverbs-devel
 librdmacm-devel
 numactl-devel


### PR DESCRIPTION
Request from @jakirkham and @quasiben and following https://github.com/jakirkham-feedstocks/ucx-split-feedstock/commit/e4a1bd1a7bedeccb77bd0e0057ea063339bdb6bb