### PR TITLE
Remove branch-0.12 from nightly and CUDA 9.2

### DIFF
--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -14,18 +14,9 @@ UCX_PROC_VERSION:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - branch-0.12
   - branch-0.13
 
 CUDA_VERSION:
   - 10.2
   - 10.1
   - 10.0
-  - 9.2
-
-exclude:
-  - UCX_PY_COMMIT: branch-0.12
-    CUDA_VERSION: 10.2
-  - UCX_PY_COMMIT: branch-0.13
-    CUDA_VERSION: 9.2
-    


### PR DESCRIPTION
After the 0.12 release we no longer need to build nightlies, also CUDA 9.2 is no longer supported in 0.13