### PR TITLE
FIX Pin ucx-py to ucx version not build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -125,7 +125,7 @@ outputs:
       run:
         - python
         - numpy
-        - {{ pin_subpackage("ucx", exact=True) }}
+        - ucx {{ ucx_version }}+g{{ ucx_commit }}
       run_constrained:
         - ucx-proc * {{ ucx_proc_type }}
     script: install_ucx-py.sh


### PR DESCRIPTION
This should pick up the correct CUDA based on the specified cudatoolkit