### PR TITLE
Update the recipe's maintainer list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Akshay-Venkatesh @TomAugspurger @jakirkham @quasiben
+* @jakirkham @mike-wendt @pentschev @quasiben

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+on:
+  status: {}
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  regro-cf-autotick-bot-action:
+    runs-on: ubuntu-latest
+    name: regro-cf-autotick-bot-action
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: regro-cf-autotick-bot-action
+        id: regro-cf-autotick-bot-action
+        uses: regro/cf-autotick-bot-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webservices.yml
+++ b/.github/workflows/webservices.yml
@@ -1,0 +1,12 @@
+on: repository_dispatch
+
+jobs:
+  webservices:
+    runs-on: ubuntu-latest
+    name: webservices
+    steps:
+      - name: webservices
+        id: webservices
+        uses: conda-forge/webservices-dispatch-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -183,8 +183,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@Akshay-Venkatesh](https://github.com/Akshay-Venkatesh/)
-* [@TomAugspurger](https://github.com/TomAugspurger/)
 * [@jakirkham](https://github.com/jakirkham/)
+* [@mike-wendt](https://github.com/mike-wendt/)
+* [@pentschev](https://github.com/pentschev/)
 * [@quasiben](https://github.com/quasiben/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -149,7 +149,7 @@ about:
 
 extra:
   recipe-maintainers:
-    - Akshay-Venkatesh
     - jakirkham
+    - mike-wendt
+    - pentschev
     - quasiben
-    - TomAugspurger


### PR DESCRIPTION
Include people more actively involved in the recipe at present to ensure the right people are requested for reviews and we are not generating noise for others.