### PR TITLE
Link `libcuda` last

### DIFF
--- a/recipe/ib_registration_cache.patch
+++ b/recipe/ib_registration_cache.patch
@@ -11,7 +11,7 @@ index 03786e71d..6594b1b8a 100644
 -libucs_la_LDFLAGS  = -ldl $(NUMA_LIBS) -version-info $(SOVERSION)
 +libucs_la_CPPFLAGS = $(BASE_CPPFLAGS) $(CUDA_CPPFLAGS) -DUCX_MODULE_DIR=\"$(moduledir)\"
 +libucs_la_CFLAGS   = $(BASE_CFLAGS) $(CUDA_CFLAGS)
-+libucs_la_LDFLAGS  = -lcuda -ldl $(NUMA_LIBS) $(patsubst %, -Xlinker %, $(CUDA_LDFLAGS)) -version-info $(SOVERSION)
++libucs_la_LDFLAGS  = -ldl $(NUMA_LIBS) $(patsubst %, -Xlinker %, $(CUDA_LDFLAGS)) -version-info $(SOVERSION) -lcuda
  libucs_ladir       = $(includedir)/ucs
  libucs_la_LIBADD   = $(LIBM) $(top_builddir)/src/ucm/libucm.la
  


### PR DESCRIPTION
As it appears there are issues loading `libucm_cuda`, which also links to `libcuda`, make sure the we link to `libcuda` last. This way if `libucm_cuda` loads `libcuda`, we don't clash with it.

xref: https://github.com/rapidsai/ucx-py/issues/435#issuecomment-596012583

cc @quasiben @pentschev