### PR TITLE
Fix ucx-py uploads

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,6 @@ source:
 
 build:
   skip: true  # [not linux]
-  skip: true  # [cuda_compiler_version != "10.2"]
   number: 0
   script_env:
     - UCX_VERSION
@@ -102,7 +101,7 @@ outputs:
     build:
       number: {{ ucx_py_number }}
       string: py{{ py_version }}_{{ ucx_py_number }}
-      skip: true  # [py<36 or cuda_compiler_version != "None"]
+      skip: true  # [py<36 or cuda_compiler_version != "10.2"]
       script_env:
         - CUDA_HOME
       ignore_run_exports:


### PR DESCRIPTION
ucx should be built/uploaded under all CUDA versions

ucx-py should only be built/uploaded under a single (10.2) CUDA version

I think this changes enforces that.