### PR TITLE
Drop `run_constrained` from `ucx-py`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -129,8 +129,6 @@ outputs:
         - numpy
         - psutil
         - ucx {{ ucx_version }}+g{{ ucx_commit }}
-      run_constrained:
-        - ucx-proc * {{ ucx_proc_type }}
     script: install_ucx-py.sh
     about:
       home: https://github.com/rapidsai/ucx-py


### PR DESCRIPTION
As `ucx-py` is agnostic to CPU/GPU builds, there is no need to have this constraint to determine whether a CPU or GPU build of `ucx-py` is installed (such a thing doesn't exist). So drop this constraint so it can be used easily in both cases.