### PR TITLE
Ensure dependencies are not installed

### DIFF
--- a/recipe/install_ucx-py.sh
+++ b/recipe/install_ucx-py.sh
@@ -3,4 +3,5 @@
 set -xeuo pipefail
 
 cd "${SRC_DIR}/ucx-py"
-$PYTHON -m pip install . -vv
+mkdir -p pip_cache
+$PYTHON -m pip install --no-index --no-deps --ignore-installed --cache-dir ./pip_cache . -vv


### PR DESCRIPTION
While [conda-build does configure pip to not install dependencies amongst other things]( https://github.com/conda/conda-build/blob/ba6cf7ab75de9f7961e1ce85c090baf52ce46cbc/conda_build/build.py#L2426-L2440 ), that does not appear to be respected here. So add in our own pip flags to ensure that dependencies are not getting installed and included in the package.

cc @quasiben (this should fix the issue we saw earlier)