### PR TITLE
Drop `-` in UCX version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 #### START - Config version naming (right side is default value)
-{% set ucx_version = environ.get("UCX_VER", "1.8.0dev").lstrip('v') %}
+{% set ucx_version = environ.get("UCX_VER", "1.8.0dev").lstrip('v').replace("-", "") %}
 {% set ucx_number = environ.get("UCX_BUILD_NUMBER", 0) %}
 {% set ucx_proc_version = environ.get("UCX_PROC_VER", "1.0.0") %}
 {% set ucx_py_version = environ.get("UCX_PY_VER", "0.14a").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}


### PR DESCRIPTION
For RC versions UCX sometimes includes a `-`. Unfortunately this is not something Conda likes. So just drop the `-`. There don't appear to be other `-`s in the version. So this should only affect these RC cases.