### PR TITLE
Drop Python 3.6

### DIFF
--- a/.ci_support/migrations/python38.yaml
+++ b/.ci_support/migrations/python38.yaml
@@ -1,35 +1,16 @@
 migrator_ts: 1569538102   # The timestamp of when the migration was made
-__migrator: 
-  kind: 
+__migrator:
+  kind:
     version
   exclude:
     - c_compiler
     - vc
     - cxx_compiler
   migration_number:  # Only use this if the bot messes up, putting this in will cause a complete rerun of the migration
-    1 
+    1
   bump_number: 0
 
 python:
-  - 2.7.* *_cpython   # [not (aarch64 or ppc64le)]
   - 3.6.* *_cpython
   - 3.7.* *_cpython
   - 3.8.* *_cpython
-
-c_compiler:                    # [win]
-  - vs2008                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
-
-cxx_compiler:                  # [win]
-  - vs2008                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
-  - vs2015                     # [win]
-
-vc:                    # [win]
-  - 9                  # [win]
-  - 14                 # [win]
-  - 14                 # [win]
-  - 14                 # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -105,7 +105,7 @@ outputs:
       string: py{{ py_version }}_{{ ucx_py_number }}
       skip: true  # [py<36 or cuda_compiler_version != "10.2"]
       script_env:
-        - CUDA_HOME # [cuda_compiler_version != "None"]
+        - CUDA_HOME                      # [cuda_compiler_version != "None"]
       ignore_run_exports:
         - cudatoolkit                    # [cuda_compiler_version != "None"]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ outputs:
     build:
       number: {{ ucx_py_number }}
       string: py{{ py_version }}_{{ ucx_py_number }}
-      skip: true                         # [py<36]
+      skip: true                         # [py<37]
       skip: true                         # [cuda_compiler_version != "None"]
       script_env:
         - CUDA_HOME                      # [cuda_compiler_version != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,8 @@ outputs:
     build:
       number: {{ ucx_py_number }}
       string: py{{ py_version }}_{{ ucx_py_number }}
-      skip: true  # [py<36 or cuda_compiler_version != "None"]
+      skip: true  # [py<36]
+      skip: true  # [cuda_compiler_version != "None"]
       script_env:
         - CUDA_HOME                      # [cuda_compiler_version != "None"]
       ignore_run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set ucx_py_version = environ.get("UCX_PY_VER", "0.14a").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set ucx_py_number = environ.get("UCX_PY_BUILD_NUMBER", 0) %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '9.2').split('.')[:2]) %}
-{% set py_version = environ.get('CONDA_PY', '36') %}
+{% set py_version = environ.get('CONDA_PY', '37') %}
 #### END - Config version naming
 
 #### START - Config source commits (right side is default value)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ outputs:
     build:
       number: {{ ucx_py_number }}
       string: py{{ py_version }}_{{ ucx_py_number }}
-      skip: true  # [py<36 or cuda_compiler_version != "10.2"]
+      skip: true  # [py<36 or cuda_compiler_version != "None"]
       script_env:
         - CUDA_HOME                      # [cuda_compiler_version != "None"]
       ignore_run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,8 +103,8 @@ outputs:
     build:
       number: {{ ucx_py_number }}
       string: py{{ py_version }}_{{ ucx_py_number }}
-      skip: true  # [py<36]
-      skip: true  # [cuda_compiler_version != "None"]
+      skip: true                         # [py<36]
+      skip: true                         # [cuda_compiler_version != "None"]
       script_env:
         - CUDA_HOME                      # [cuda_compiler_version != "None"]
       ignore_run_exports:


### PR DESCRIPTION
Closes https://github.com/rapidsai/ops/issues/1019

Drops Python 3.6 builds of `ucx-py`. CUDA 10.0 was dropped in PR ( https://github.com/rapidsai/ucx-split-feedstock/pull/34 ).

Note that migration files and variant files still show Python 3.6. However these are not actually built (as I verified locally).

cc @mike-wendt