### PR TITLE
Drop ibverbs

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,16 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      linux_cuda_compiler_version10.1:
-        CONFIG: linux_cuda_compiler_version10.1
+      linux_64_cuda_compiler_version10.1:
+        CONFIG: linux_64_cuda_compiler_version10.1
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.1
-      linux_cuda_compiler_version10.2:
-        CONFIG: linux_cuda_compiler_version10.2
+      linux_64_cuda_compiler_version10.2:
+        CONFIG: linux_64_cuda_compiler_version10.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
-      linux_cuda_compiler_versionNone:
-        CONFIG: linux_cuda_compiler_versionNone
+      linux_64_cuda_compiler_versionNone:
+        CONFIG: linux_64_cuda_compiler_versionNone
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
     maxParallel: 8

--- a/.ci_support/linux_64_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.2'
+- '10.1'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.2
+- condaforge/linux-anvil-cuda:10.1
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -24,6 +24,8 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+target_platform:
+- linux-64
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- None
+- '10.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:10.2
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -24,6 +24,8 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+target_platform:
+- linux-64
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -9,13 +9,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- '10.1'
+- None
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-cuda:10.1
+- condaforge/linux-anvil-comp7
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -24,6 +24,8 @@ python:
 - 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
+target_platform:
+- linux-64
 zip_keys:
 - - cuda_compiler_version
   - docker_image

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -38,7 +38,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-    --suppress-variables \
+    --suppress-variables ${EXTRA_CB_OPTIONS:-} \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,7 +31,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y librdmacm-devel numactl-devel
+/usr/bin/sudo -n yum install -y numactl-devel
 
 
 # make the build number clobber

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,7 +31,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libibcm-devel libibverbs-devel librdmacm-devel numactl-devel
+/usr/bin/sudo -n yum install -y libibcm-devel librdmacm-devel numactl-devel
 
 
 # make the build number clobber

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,7 +31,7 @@ source run_conda_forge_build_setup
 # "recipe/yum_requirements.txt" file. After updating that file,
 # run "conda smithy rerender" and this line will be updated
 # automatically.
-/usr/bin/sudo -n yum install -y libibcm-devel librdmacm-devel numactl-devel
+/usr/bin/sudo -n yum install -y librdmacm-devel numactl-devel
 
 
 # make the build number clobber

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2019, conda-forge
+Copyright (c) 2015-2020, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -29,48 +29,30 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_cuda_compiler_version10.1</td>
+              <td>linux_64_cuda_compiler_version10.1</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.1" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version10.1" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_version10.2</td>
+              <td>linux_64_cuda_compiler_version10.2</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_version10.2" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version10.2" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_cuda_compiler_versionNone</td>
+              <td>linux_64_cuda_compiler_versionNone</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_cuda_compiler_versionNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_versionNone" alt="variant">
                 </a>
               </td>
             </tr>
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>OSX</td>
-    <td>
-      <img src="https://img.shields.io/badge/OSX-disabled-lightgrey.svg" alt="OSX disabled">
-    </td>
-  </tr>
-  <tr>
-    <td>Windows</td>
-    <td>
-      <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
-    </td>
-  </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,7 +43,7 @@ conda config --show-sources
 conda list --show-channel-urls
 
 # Add settings for current CUDA version
-cat .ci_support/linux_cuda_compiler_version${CUDA_VER}.yaml >> recipe/conda_build_config.yaml
+cat .ci_support/linux_64_cuda_compiler_version${CUDA_VER}.yaml >> recipe/conda_build_config.yaml
 
 # Allow insecure files to work with out conda mirror/proxy
 echo "ssl_verify: false" >> /opt/conda/.condarc

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -18,7 +18,6 @@ cd "${SRC_DIR}/ucx"
     --enable-mt \
     --enable-numa \
     --with-gnu-ld \
-    --with-cm \
     --with-rdmacm \
     ${CUDA_CONFIG_ARG}
 

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -18,7 +18,6 @@ cd "${SRC_DIR}/ucx"
     --enable-mt \
     --enable-numa \
     --with-gnu-ld \
-    --with-rdmacm \
     ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}

--- a/recipe/install_ucx.sh
+++ b/recipe/install_ucx.sh
@@ -20,7 +20,6 @@ cd "${SRC_DIR}/ucx"
     --with-gnu-ld \
     --with-cm \
     --with-rdmacm \
-    --with-verbs \
     ${CUDA_CONFIG_ARG}
 
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,6 @@ outputs:
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibcm-devel") }}
-        - {{ cdt("libibverbs-devel") }}
         - {{ cdt("librdmacm-devel") }}
         - {{ cdt("numactl-devel") }}
         - automake
@@ -117,7 +116,6 @@ outputs:
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
         - {{ cdt("libibcm") }}
-        - {{ cdt("libibverbs") }}
         - {{ cdt("librdmacm") }}
         - {{ cdt("numactl") }}
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,6 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
-        - {{ cdt("librdmacm-devel") }}
         - {{ cdt("numactl-devel") }}
         - automake
         - autoconf
@@ -114,7 +113,6 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
-        - {{ cdt("librdmacm") }}
         - {{ cdt("numactl") }}
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,6 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
-        - {{ cdt("libibcm-devel") }}
         - {{ cdt("librdmacm-devel") }}
         - {{ cdt("numactl-devel") }}
         - automake
@@ -115,7 +114,6 @@ outputs:
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("libnl") }}
-        - {{ cdt("libibcm") }}
         - {{ cdt("librdmacm") }}
         - {{ cdt("numactl") }}
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,6 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
-        - {{ cdt("libnl") }}
         - {{ cdt("numactl-devel") }}
         - automake
         - autoconf
@@ -112,7 +111,6 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
-        - {{ cdt("libnl") }}
         - {{ cdt("numactl") }}
       host:
         - python

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,4 +1,3 @@
 libibcm-devel
-libibverbs-devel
 librdmacm-devel
 numactl-devel

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,3 +1,2 @@
-libibcm-devel
 librdmacm-devel
 numactl-devel

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,2 +1,1 @@
-librdmacm-devel
 numactl-devel


### PR DESCRIPTION
This drops `ibverbs` from the `ucx` package. We are doing this as using the `ibverbs` package from CentOS 6 does not appear to be sufficient when reusing `ucx` packages built against it with OFED.