### PR TITLE
ENH CUDA 11 support without IB

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_64_cuda_compiler_version10.2
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-cuda:10.2
+      linux_64_cuda_compiler_version11.0:
+        CONFIG: linux_64_cuda_compiler_version11.0
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: mikewendt/linux-anvil-cuda:11.0
       linux_64_cuda_compiler_versionNone:
         CONFIG: linux_64_cuda_compiler_versionNone
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/linux_64_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -21,7 +23,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
 target_platform:

--- a/.ci_support/linux_64_cuda_compiler_version10.1.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.1.yaml
@@ -28,5 +28,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cuda_compiler_version
+- - cdt_name
+  - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -2,6 +2,8 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -21,7 +23,6 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.6.* *_cpython
 - 3.7.* *_cpython
 - 3.8.* *_cpython
 target_platform:

--- a/.ci_support/linux_64_cuda_compiler_version10.2.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version10.2.yaml
@@ -28,5 +28,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cuda_compiler_version
+- - cdt_name
+  - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_version11.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0.yaml
@@ -3,7 +3,7 @@ c_compiler:
 c_compiler_version:
 - '7'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_64_cuda_compiler_version11.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0.yaml
@@ -11,13 +11,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- None
+- '11.0'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- mikewendt/linux-anvil-cuda:11.0
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_64_cuda_compiler_version11.0.yaml
+++ b/.ci_support/linux_64_cuda_compiler_version11.0.yaml
@@ -28,5 +28,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cuda_compiler_version
+- - cdt_name
+  - cuda_compiler_version
   - docker_image

--- a/.ci_support/linux_64_cuda_compiler_versionNone.yaml
+++ b/.ci_support/linux_64_cuda_compiler_versionNone.yaml
@@ -28,5 +28,6 @@ python:
 target_platform:
 - linux-64
 zip_keys:
-- - cuda_compiler_version
+- - cdt_name
+  - cuda_compiler_version
   - docker_image

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>linux_64_cuda_compiler_version11.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ucx-split-feedstock?branchName=master&jobName=linux&configuration=linux_64_cuda_compiler_version11.0" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_64_cuda_compiler_versionNone</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7481&branchName=master">

--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -1,5 +1,6 @@
 FROM_IMAGE:
   - condaforge/linux-anvil-cuda
+  - mikewendt/linux-anvil-cuda
   - condaforge/linux-anvil-comp7
 
 CONDA_USERNAME:
@@ -19,14 +20,25 @@ UCX_PY_COMMIT:
   - branch-0.16
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - None
 
 exclude:
   - FROM_IMAGE: condaforge/linux-anvil-comp7
+    CUDA_VER: 11.0
+  - FROM_IMAGE: condaforge/linux-anvil-cuda
+    CUDA_VER: 11.0
+  - FROM_IMAGE: condaforge/linux-anvil-comp7
+    CUDA_VER: 10.2
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
     CUDA_VER: 10.2
   - FROM_IMAGE: condaforge/linux-anvil-comp7
     CUDA_VER: 10.1
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
+    CUDA_VER: 10.1
   - FROM_IMAGE: condaforge/linux-anvil-cuda
+    CUDA_VER: None
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
     CUDA_VER: None

--- a/ci/axis/release.yml
+++ b/ci/axis/release.yml
@@ -18,14 +18,25 @@ UCX_PY_COMMIT:
   - master
 
 CUDA_VER:
+  - 11.0
   - 10.2
   - 10.1
   - None
 
 exclude:
   - FROM_IMAGE: condaforge/linux-anvil-comp7
+    CUDA_VER: 11.0
+  - FROM_IMAGE: condaforge/linux-anvil-cuda
+    CUDA_VER: 11.0
+  - FROM_IMAGE: condaforge/linux-anvil-comp7
+    CUDA_VER: 10.2
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
     CUDA_VER: 10.2
   - FROM_IMAGE: condaforge/linux-anvil-comp7
     CUDA_VER: 10.1
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
+    CUDA_VER: 10.1
   - FROM_IMAGE: condaforge/linux-anvil-cuda
+    CUDA_VER: None
+  - FROM_IMAGE: mikewendt/linux-anvil-cuda
     CUDA_VER: None

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -54,11 +54,11 @@ env
 
 # Start conda build
 gpuci_logger "Starting conda build..."
-conda build --override-channels -c conda-forge -c nvidia .
+conda build --override-channels -c conda-forge -c nvidia -c rapidsai-nightly .
 
 # Get conda build output
 gpuci_logger "Getting conda build output..."
-conda build --override-channels -c conda-forge -c nvidia . --output > conda.output
+conda build --override-channels -c conda-forge -c nvidia -c rapidsai-nightly . --output > conda.output
 
 # Uploda files to anaconda
 if [ ! -z "${MY_UPLOAD_KEY}" ] ; then

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -43,7 +43,7 @@ conda config --show-sources
 conda list --show-channel-urls
 
 # Add settings for current CUDA version
-cat .ci_support/linux_64_cuda_compiler_version${CUDA_VER}.yaml >> recipe/conda_build_config.yaml
+cat .ci_support/linux_64_cuda_compiler_version${CUDA_VER}.yaml > recipe/conda_build_config.yaml
 
 # Allow insecure files to work with out conda mirror/proxy
 echo "ssl_verify: false" >> /opt/conda/.condarc

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,17 @@
 channel_targets:
   - conda-forge rc_ucx
+cdt_name:
+  - cos6                       # [cuda_compiler_version != "11.0"]
+  - cos7                       # [cuda_compiler_version == "11.0"]
+cuda_compiler_version:
+  - 10.1                       # [linux64]
+  - 10.2                       # [linux64]
+  - 11.0                       # [linux64]
+docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") or (os.environ.get("CONFIG_VERSION", "1") == "1" and linux)]
+  - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+  - mikewendt/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
+zip_keys:
+  -                             # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,8 +4,10 @@ python:
 channel_targets:
   - conda-forge rc_ucx
 cdt_name:
-  - cos6                       # [cuda_compiler_version != "11.0"]
-  - cos7                       # [cuda_compiler_version == "11.0"]
+  - cos6
+  - cos6                       # [linux64]
+  - cos6                       # [linux64]
+  - cos7                       # [linux64]
 cuda_compiler_version:
   - None
   - 10.1                       # [linux64]
@@ -18,5 +20,6 @@ docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").
   - mikewendt/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
 zip_keys:
   -                             # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
-    - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
-    - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - cdt_name                  # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+  - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -20,6 +20,6 @@ docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").
   - mikewendt/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
 zip_keys:
   -                             # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - cdt_name                  # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
-  - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    - cdt_name                  # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    - cuda_compiler_version     # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]
+    - docker_image              # [(os.environ.get("CONFIG_VERSION", "1") == "1" and linux64) or os.environ.get("BUILD_PLATFORM") == "linux-64"]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,13 +1,18 @@
+python:
+  - 3.7.* *_cpython
+  - 3.8.* *_cpython
 channel_targets:
   - conda-forge rc_ucx
 cdt_name:
   - cos6                       # [cuda_compiler_version != "11.0"]
   - cos7                       # [cuda_compiler_version == "11.0"]
 cuda_compiler_version:
+  - None
   - 10.1                       # [linux64]
   - 10.2                       # [linux64]
   - 11.0                       # [linux64]
 docker_image:                           # [os.environ.get("BUILD_PLATFORM", "").startswith("linux") or (os.environ.get("CONFIG_VERSION", "1") == "1" and linux)]
+  - condaforge/linux-anvil-comp7        # [os.environ.get("BUILD_PLATFORM") == "linux-64" or (os.environ.get("CONFIG_VERSION", "1") == "1" and linux64)]
   - condaforge/linux-anvil-cuda:10.1    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - condaforge/linux-anvil-cuda:10.2    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]
   - mikewendt/linux-anvil-cuda:11.0    # [linux64 and (os.environ.get("BUILD_PLATFORM") == "linux-64" or os.environ.get("CONFIG_VERSION", "1") == "1")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -69,6 +69,7 @@ outputs:
     requirements:
       build:
         - {{ compiler("c") }}
+        - sysroot_linux-64 2.17          # [linux64 and cuda_compiler_version == "11.0"]
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("numactl-devel") }}
@@ -109,6 +110,7 @@ outputs:
     requirements:
       build:
         - {{ compiler("c") }}
+        - sysroot_linux-64 2.17          # [linux64 and cuda_compiler_version == "11.0"]
         - {{ compiler("cxx") }}
         - {{ compiler("cuda") }}         # [cuda_compiler_version != "None"]
         - {{ cdt("numactl") }}


### PR DESCRIPTION
Follows #40 and adds CUDA 11 support based on initial work in #37 

Uses custom CUDA 11 anvil until a conda-forge one is available. Re-rendered but there is an issue with the CUDA 11 template. I've had to add a custom patch to it [here](https://github.com/rapidsai/ucx-split-feedstock/pull/41/commits/c7a397733f1ee750df49418a99dc3be446fd8ce6), as these [lines](https://github.com/rapidsai/ucx-split-feedstock/blob/enh-cuda11-noib/recipe/conda_build_config.yaml#L7-L8) in the `conda_build_config.yaml` do not work.