### PR TITLE
FIX Build ucx-py from main branch for release

### DIFF
--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -16,7 +16,6 @@ UCX_PROC_VER:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - branch-0.15
   - branch-0.16
 
 CUDA_VER:

--- a/ci/axis/release.yml
+++ b/ci/axis/release.yml
@@ -16,7 +16,7 @@ UCX_PROC_VER:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - master
+  - main
 
 CUDA_VER:
   - 11.0


### PR DESCRIPTION
With the default branch changes we need to build from `main` instead to get the correct git tags for release builds.