### PR TITLE
ENH Enable branch-0.18 builds

### DIFF
--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -16,8 +16,8 @@ UCX_PROC_VER:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - branch-0.16
   - branch-0.17
+  - branch-0.18
 
 CUDA_VER:
   - 11.0


### PR DESCRIPTION
Unblocks conda builds for v0.18 that are failing and thereby unblocks the following:

- rapidsai/integration#180
- rapidsai/gpuci-build-environment#149
- rapidsai/docker#222