### PR TITLE
Update libhwloc version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -118,7 +118,7 @@ outputs:
         - python
         - pip
         - cython >=0.29.14,<3.0.0a0
-        - libhwloc
+        - libhwloc >=2.3.0,<2.4.0a0
         - ucx
       run:
         - python


### PR DESCRIPTION
`libhwloc` 2.4.0 requires `libgcc-ng>=9.3.0` but we're still on 7.5, so restrict libhwloc to a compatible version