### PR TITLE
Add v0.20 to nightly builds

### DIFF
--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -16,6 +16,7 @@ UCX_PROC_VER:
 
 UCX_PY_COMMIT:
   - branch-0.19
+  - branch-0.20
 
 CUDA_VER:
   - 11.2


### PR DESCRIPTION
Just enable builds for `branch-0.20`.