### PR TITLE
Update to UCX 1.11.2

### DIFF
--- a/ci/axis/nightly-arm64.yml
+++ b/ci/axis/nightly-arm64.yml
@@ -6,10 +6,10 @@ CONDA_USERNAME:
   - rapidsai-nightly
 
 UCX_VER:
-  - 1.11.1
+  - 1.11.2
 
 UCX_COMMIT:
-  - v1.11.1
+  - v1.11.2
 
 UCX_PROC_VER:
   - 1.0.0

--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -7,10 +7,10 @@ CONDA_USERNAME:
   - rapidsai-nightly
 
 UCX_VER:
-  - 1.11.1
+  - 1.11.2
 
 UCX_COMMIT:
-  - v1.11.1
+  - v1.11.2
 
 UCX_PROC_VER:
   - 1.0.0

--- a/ci/axis/release-arm64.yml
+++ b/ci/axis/release-arm64.yml
@@ -6,10 +6,10 @@ CONDA_USERNAME:
   - rapidsai
 
 UCX_VER:
-  - 1.11.1
+  - 1.11.2
 
 UCX_COMMIT:
-  - v1.11.1
+  - v1.11.2
 
 UCX_PROC_VER:
   - 1.0.0

--- a/ci/axis/release.yml
+++ b/ci/axis/release.yml
@@ -7,10 +7,10 @@ CONDA_USERNAME:
   - rapidsai
 
 UCX_VER:
-  - 1.11.1
+  - 1.11.2
 
 UCX_COMMIT:
-  - v1.11.1
+  - v1.11.2
 
 UCX_PROC_VER:
   - 1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,17 @@
 #### START - Config version naming (right side is default value)
-{% set ucx_version = environ.get("UCX_VER", "v1.11.1").lstrip('v').replace("-", "") %}
+{% set ucx_version = environ.get("UCX_VER", "v1.11.2").lstrip('v').replace("-", "") %}
 {% set ucx_number = environ.get("UCX_BUILD_NUMBER", 0) %}
 {% set ucx_proc_version = environ.get("UCX_PROC_VER", "1.0.0") %}
-{% set ucx_py_version = environ.get("UCX_PY_VER", "0.22").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
+{% set ucx_py_version = environ.get("UCX_PY_VER", "0.23").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set ucx_py_number = environ.get("UCX_PY_BUILD_NUMBER", 0) %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '11.2').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', '38') %}
 #### END - Config version naming
 
 #### START - Config source commits (right side is default value)
-{% set ucx_commit = environ.get("UCX_COMMIT", "c58db6b") %}
+{% set ucx_commit = environ.get("UCX_COMMIT", "ef2bbcf") %}
 {% set ucx_py_commit = environ.get("UCX_PY_COMMIT", "9c11581") %}
+{% set ucx_py_commit = environ.get("UCX_PY_COMMIT", "99b672d") %}
 #### END - Config source commits
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}


### PR DESCRIPTION
We've been testing 1.11.2 nightly for about a month now and do not know of any issues with that upgrade, plus it fixes a few error handling issues from UCX 1.11.1.