### PR TITLE
Ensure working `conda-build` version is used

### DIFF
--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -31,7 +31,7 @@ xargs yum -y install < recipe/yum_requirements.txt
 # Fetch pkgs for build
 gpuci_logger "Install conda pkgs needed for build..."
 # Previous versions of conda-build cause a build error. See https://github.com/conda-forge/conda-build-feedstock/pull/169
-MORE_PKGS="conda-build >=3.21.6"
+MORE_PKGS="conda-build>=3.21.6"
 if [ "$CUDA_VER" != "None" ] ; then
   MORE_PKGS="${MORE_PKGS} cudatoolkit=${CUDA_VER}"
 fi

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -30,6 +30,7 @@ xargs yum -y install < recipe/yum_requirements.txt
 
 # Fetch pkgs for build
 gpuci_logger "Install conda pkgs needed for build..."
+conda install -y "conda-build >=3.21.6" # Previous versions of conda-build cause a build error. See https://github.com/conda-forge/conda-build-feedstock/pull/169
 if [ "$CUDA_VER" != "None" ] ; then
   conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify cudatoolkit=$CUDA_VER
 else

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -36,7 +36,7 @@ if [ "$CUDA_VER" != "None" ] ; then
   MORE_PKGS="${MORE_PKGS} cudatoolkit=${CUDA_VER}"
 fi
 
-conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify "${MORE_PKGS}"
+conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify ${MORE_PKGS}
 
 # Print diagnostic information
 gpuci_logger "Print conda info..."

--- a/ci/cpu/build.sh
+++ b/ci/cpu/build.sh
@@ -30,12 +30,13 @@ xargs yum -y install < recipe/yum_requirements.txt
 
 # Fetch pkgs for build
 gpuci_logger "Install conda pkgs needed for build..."
-conda install -y "conda-build >=3.21.6" # Previous versions of conda-build cause a build error. See https://github.com/conda-forge/conda-build-feedstock/pull/169
+# Previous versions of conda-build cause a build error. See https://github.com/conda-forge/conda-build-feedstock/pull/169
+MORE_PKGS="conda-build >=3.21.6"
 if [ "$CUDA_VER" != "None" ] ; then
-  conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify cudatoolkit=$CUDA_VER
-else
-  conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify
+  MORE_PKGS="${MORE_PKGS} cudatoolkit=${CUDA_VER}"
 fi
+
+conda install -y -k -c nvidia -c conda-forge -c defaults conda-verify "${MORE_PKGS}"
 
 # Print diagnostic information
 gpuci_logger "Print conda info..."


### PR DESCRIPTION
This PR ensures that at least version `3.21.6` of `conda-build` is installed since previous versions seem to be having issues.