### PR TITLE
Remove extraneous `gpuci` images

### DIFF
--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -1,7 +1,6 @@
 FROM_IMAGE:
   - quay.io/condaforge/linux-anvil-cuda
   - quay.io/condaforge/linux-anvil-comp7
-  - gpuci/linux-anvil-cuda
 
 CONDA_USERNAME:
   - rapidsai-nightly
@@ -38,14 +37,3 @@ exclude:
 
   - FROM_IMAGE: quay.io/condaforge/linux-anvil-cuda
     CUDA_VER: None
-
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: None
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 11.2
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 11.0
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 10.2
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 10.1

--- a/ci/axis/release.yml
+++ b/ci/axis/release.yml
@@ -1,7 +1,6 @@
 FROM_IMAGE:
   - quay.io/condaforge/linux-anvil-cuda
   - quay.io/condaforge/linux-anvil-comp7
-  - gpuci/linux-anvil-cuda
 
 CONDA_USERNAME:
   - rapidsai
@@ -36,15 +35,4 @@ exclude:
     CUDA_VER: 10.1
 
   - FROM_IMAGE: quay.io/condaforge/linux-anvil-cuda
-    CUDA_VER: None
-
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 11.2
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 11.0
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 10.2
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
-    CUDA_VER: 10.1
-  - FROM_IMAGE: gpuci/linux-anvil-cuda
     CUDA_VER: None


### PR DESCRIPTION
The `gpuci` image entries here are leftover from before CUDA Enhanced Compatibility builds were a thing. They are no longer used and can therefore be removed.