### PR TITLE
Update to UCX 1.12.0

### DIFF
--- a/ci/axis/nightly-arm64.yml
+++ b/ci/axis/nightly-arm64.yml
@@ -6,16 +6,15 @@ CONDA_USERNAME:
   - rapidsai-nightly
 
 UCX_VER:
-  - 1.11.2
+  - 1.12.0
 
 UCX_COMMIT:
-  - v1.11.2
+  - v1.12.0
 
 UCX_PROC_VER:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - branch-0.23
   - branch-0.24
 
 CUDA_VER:

--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -6,16 +6,15 @@ CONDA_USERNAME:
   - rapidsai-nightly
 
 UCX_VER:
-  - 1.11.2
+  - 1.12.0
 
 UCX_COMMIT:
-  - v1.11.2
+  - v1.12.0
 
 UCX_PROC_VER:
   - 1.0.0
 
 UCX_PY_COMMIT:
-  - branch-0.23
   - branch-0.24
 
 CUDA_VER:

--- a/ci/axis/release-arm64.yml
+++ b/ci/axis/release-arm64.yml
@@ -6,10 +6,10 @@ CONDA_USERNAME:
   - rapidsai
 
 UCX_VER:
-  - 1.11.2
+  - 1.12.0
 
 UCX_COMMIT:
-  - v1.11.2
+  - v1.12.0
 
 UCX_PROC_VER:
   - 1.0.0

--- a/ci/axis/release.yml
+++ b/ci/axis/release.yml
@@ -6,10 +6,10 @@ CONDA_USERNAME:
   - rapidsai
 
 UCX_VER:
-  - 1.11.2
+  - 1.12.0
 
 UCX_COMMIT:
-  - v1.11.2
+  - v1.12.0
 
 UCX_PROC_VER:
   - 1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,16 @@
 #### START - Config version naming (right side is default value)
-{% set ucx_version = environ.get("UCX_VER", "v1.11.2").lstrip('v').replace("-", "") %}
+{% set ucx_version = environ.get("UCX_VER", "v1.12.0").lstrip('v').replace("-", "") %}
 {% set ucx_number = environ.get("UCX_BUILD_NUMBER", 0) %}
 {% set ucx_proc_version = environ.get("UCX_PROC_VER", "1.0.0") %}
-{% set ucx_py_version = environ.get("UCX_PY_VER", "0.23").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
+{% set ucx_py_version = environ.get("UCX_PY_VER", "0.24").lstrip('v') + environ.get('VERSION_SUFFIX', '') %}
 {% set ucx_py_number = environ.get("UCX_PY_BUILD_NUMBER", 0) %}
 {% set cuda_version = '.'.join(environ.get('CUDA_VER', '11.2').split('.')[:2]) %}
 {% set py_version = environ.get('CONDA_PY', '38') %}
 #### END - Config version naming
 
 #### START - Config source commits (right side is default value)
-{% set ucx_commit = environ.get("UCX_COMMIT", "ef2bbcf") %}
-{% set ucx_py_commit = environ.get("UCX_PY_COMMIT", "9c11581") %}
-{% set ucx_py_commit = environ.get("UCX_PY_COMMIT", "99b672d") %}
+{% set ucx_commit = environ.get("UCX_COMMIT", "8ab494b") %}
+{% set ucx_py_commit = environ.get("UCX_PY_COMMIT", "cb13a3e") %}
 #### END - Config source commits
 
 {% set ucx_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}


### PR DESCRIPTION
Latest UCX 1.12.0 nightly tests have been successful, so we should be good moving to this release from last week.