### PR TITLE
Add `branch-0.25` to CI builds

### DIFF
--- a/ci/axis/nightly-arm64.yml
+++ b/ci/axis/nightly-arm64.yml
@@ -16,6 +16,7 @@ UCX_PROC_VER:
 
 UCX_PY_COMMIT:
   - branch-0.24
+  - branch-0.25
 
 CUDA_VER:
   - 11.2

--- a/ci/axis/nightly.yml
+++ b/ci/axis/nightly.yml
@@ -16,6 +16,7 @@ UCX_PROC_VER:
 
 UCX_PY_COMMIT:
   - branch-0.24
+  - branch-0.25
 
 CUDA_VER:
   - 11.2


### PR DESCRIPTION
This PR adds `branch-0.25` to our axis files that are used for CI builds. This will ensure that `0.25` packages get published for `ucx-py`.